### PR TITLE
Highlight optional

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -9,6 +9,7 @@
   "message"
   "enum"
   "oneof"
+  "optional"
   "repeated"
   "reserved"
   "to"


### PR DESCRIPTION
`optional` made a comeback in protobuf 3.15, so let's highlight it as a keyword similar to `repeated`.